### PR TITLE
Fixed errors from modified settings structure

### DIFF
--- a/pydrive/settings.py
+++ b/pydrive/settings.py
@@ -88,24 +88,25 @@ SETTINGS_STRUCT = {
                 'type': str,
                 'required': True,
                 'default': None
+            }
+        }
+    },
+    'service_config': {
+        'type': dict,
+        'required': False,
+        'struct': {
+            'client_user_email': {
+                'type': str,
+                'required': True,
+                'default': None
             },
-            'service_config': {
-                'type': dict,
-                'required': False,
-                'struct': {
-                    'client_user_email': {
-                    'type': str,
-                    'required': True
-                    },
-                    'client_service_email': {
-                        'type': str,
-                        'required': True
-                    },
-                    'client_pkcs12_file_path': {
-                        'type': str,
-                        'required': True
-                    }
-                }
+            'client_service_email': {
+                'type': str,
+                'required': True
+            },
+            'client_pkcs12_file_path': {
+                'type': str,
+                'required': True
             }
         }
     },

--- a/pydrive/test/settings/test6.yaml
+++ b/pydrive/test/settings/test6.yaml
@@ -1,7 +1,5 @@
-client_config_backend: 'settings'
-client_config:
-  client_id: "{{YOUR_CLIENT_ID}}"
-  client_secret: "notasecret"
+client_config_backend: 'service'
+service_config:
   client_user_email: "{{YOUR_USER_EMAIL}}"
   client_service_email: "{{YOUR_SERVICE_EMAIL}}"
   client_pkcs12_file_path: "{{YOUR_PKCS12_FILE_PATH}}"


### PR DESCRIPTION
Thank you so much for your work.
I found that the code breaks after applying the changes I suggested and fixed it.
Please review my code. Thank you.

Changes to note
- _Fixed settings structure and settings loading procedure_: Settings structure was not written as what I originally intended in my comment. Sorry I might not have been clear enough. Also, there were some problems caused by changes in settings structure which I modified in this commit.
- _Removed requirement of user_email_: although service account without user email is meaningless in Drive API, the original intention of `GoogleAuth` class was to make generic authentication wrapper class for Google API. Service account can be authenticated without user email and API user might want to supply user email after he initialized GoogleAuth class to authorize multiple accounts in same domain.
- _Pycrypto has been deleted from installation guidance message_: Pycrypto's `SignedJwtAssertionCredentials` doesn't support p12 which is required to authenticate service account.
- _Added special flow for service account_: previous code didn't build the service after successful authentication because it waited for the OAuth code which is never returned in the service account. Previous code could somehow work from the build command in `LoadAuth`. Therefore, new flow for service account, `CheckServiceAuth` is added to build right after successful authentication without checking OAuth code.
